### PR TITLE
Don't define log2f on Visual Studio 2022

### DIFF
--- a/src/nvmath/nvmath.h
+++ b/src/nvmath/nvmath.h
@@ -117,7 +117,7 @@ inline float asinf_assert(const float f)
 #define asinf asinf_assert
 #endif
 
-#if NV_CC_MSVC
+#if NV_CC_MSVC && (_MSC_VER < 1930)
 NV_FORCEINLINE float log2f(float x)
 {
     nvCheck(x >= 0);


### PR DESCRIPTION
This fixes the build on VS 2022, which currently fails with:

      C:\Users\Dale\overte-files\vcpkg\be40f209\buildtrees\nvtt\src\10e6956442-7452d53f2e.clean\src\nvmath\nvmath.h(121,22): error C2169: 'log2f': intrinsic function, cannot be defined (compiling source file C:\Users\Dale\overte-files\vcpkg\be40f209\buildtrees\nvtt\src\10e6956442-7452d53f2e.clean\src\nvmath\Fitting.cpp) [C:\Users\Dale\overte-files\vcpkg\be40f209\buildtrees\nvtt\x64-windows-rel\src\nvmath\nvmath.vcxproj]
