### PR TITLE
Fix error spam on macos

### DIFF
--- a/src/nvcore/Debug.h
+++ b/src/nvcore/Debug.h
@@ -167,8 +167,12 @@ namespace nv
 {
     inline bool isValidPtr(const void * ptr) {
     #if NV_CPU_X86_64 || POSH_CPU_PPC64 || NV_CPU_AARCH64
-        if (ptr == NULL) return true;
-        if (reinterpret_cast<uint64>(ptr) < 0x10000ULL) return false;
+        if (ptr == nullptr) return true;
+        // MACH_VM_MIN_ADDRESS == 0
+        # ifndef __MACH__
+            if (reinterpret_cast<uint64>(ptr) < 0x10000ULL) return false;
+        #endif
+
         if (reinterpret_cast<uint64>(ptr) >= 0x000007FFFFFEFFFFULL) return false;
     #else
 	    if (reinterpret_cast<uint32>(ptr) == 0xcccccccc) return false;


### PR DESCRIPTION
macos has no minimum memory address, so this causes issues. Also used nullptr since 0x0 is a perfectly cromulent memory address (implementation defined).

Fixes #2 